### PR TITLE
Adds 'softpwm' and 'qml-plugin' qmake config options

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -4,11 +4,15 @@ gpio.subdir = gpio
 gpio.target = gpio-lib
 SUBDIRS += gpio
 
-softpwm.subdir = softpwm
-softpwm.target = softpwm-lib
-SUBDIRS += softpwm
+softpwm {
+  softpwm.subdir = softpwm
+  softpwm.target = softpwm-lib
+  SUBDIRS += softpwm
+}
 
-plugins.subdir = imports
-plugins.depends = gpio-lib
-plugins.target = plugins-lib
-SUBDIRS += plugins
+qml-plugin {
+  plugins.subdir = imports
+  plugins.depends = gpio-lib
+  plugins.target = plugins-lib
+  SUBDIRS += plugins
+}


### PR DESCRIPTION
Tested this will build only the QGpio library, and tested with the options for the complete module build.

Complete module example qmake: `qmake CONFIG+=softpwm CONFIG+=qml-plugin`